### PR TITLE
Fix NPE on Xperia 4.3 stock ROMs

### DIFF
--- a/src/com/mohammadag/colouredstatusbar/hooks/XperiaTransparencyHook.java
+++ b/src/com/mohammadag/colouredstatusbar/hooks/XperiaTransparencyHook.java
@@ -53,8 +53,10 @@ public class XperiaTransparencyHook extends XC_MethodHook {
 		View outView = (View)layout.findViewById(outViewId);
 		View inView = (View)layout.findViewById(inViewId);
 
-		outView.setAlpha(0f);
-		inView.setAlpha(0f);
+		if(outView != null)
+			outView.setAlpha(0f);
+		if(inView != null)
+			inView.setAlpha(0f);
 
 		boolean isOpaque = (Boolean) XposedHelpers.callMethod(param.thisObject, "isOpaque", inViewId);
 


### PR DESCRIPTION
On Xperia 4.3 stock ROMs with tranparent launcher app, XperiaTransparencyHook throws a lot of NPEs when trying to call setAlpha on a null view.

Clarification:
swapViews() is called when SystemUI transitions between dark, light, lights-out, transparent and fully-transparent states. Each of these states has a corresponding view which is made visible/invisible in swapViews() - excepting fully-transparent. When transitioning from/to fully-transparent state, one of view ids passed as argument is "0", so, in
your code, one of the views is null which causes an NPE.

The attached patch eliminates the NPE and fixes ugly SystemUI glitches caused by this NPE.

Please let me know if you need more information on Xperia SystemUI functioning.
Thank you for your work.
