### PR TITLE
React to SearchDialogs

### DIFF
--- a/src/com/mohammadag/colouredstatusbar/hooks/ActionBarHooks.java
+++ b/src/com/mohammadag/colouredstatusbar/hooks/ActionBarHooks.java
@@ -141,6 +141,31 @@ public class ActionBarHooks {
 							invertedIconTint, mSettingsHelper.getHsvMax()), context);
 				}
 			});
+
+			Class<?> SearchManager = findClass("android.app.SearchDialog", null);
+			findAndHookMethod(SearchManager, "onStart", new XC_MethodHook() {
+				@Override
+				protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+					Context context = (Context) getObjectField(param.thisObject, "mContext");
+					int[] attributes = new int[]{android.R.attr.actionModeBackground};
+					TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(attributes);
+					Drawable drawable = styledAttributes.getDrawable(0);
+					styledAttributes.recycle();
+					int color = Utils.getMainColorFromActionBarDrawable(drawable);
+					int defaultNormal = mSettingsHelper.getDefaultTint(Tint.ICON);
+					int invertedIconTint = mSettingsHelper.getDefaultTint(Tint.ICON_INVERTED);
+					ColourChangerMod.sendColorSaveAndChangeIntent(color, Utils.getIconColorForColor(color, defaultNormal,
+							invertedIconTint, mSettingsHelper.getHsvMax()), context);
+				}
+			});
+
+			findAndHookMethod(SearchManager, "onStop", new XC_MethodHook() {
+				@Override
+				protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+					Context context = (Context) getObjectField(param.thisObject, "mContext");
+					ColourChangerMod.sendResetActionBarColorsIntent(context);
+				}
+			});
 		} catch (ClassNotFoundError e) {
 
 		} catch (NoSuchMethodError e) {


### PR DESCRIPTION
A [search dialog](http://developer.android.com/guide/topics/search/search-dialog.html#SearchDialog) is a (separate) Dialog that's shown on top of the ActionBar (and themed to look like one.) This is used by some apps, such as GitHub or TapaTalk.

We're hooking the onStart() and onStop() methods in [SearchDialog](https://github.com/android/platform_frameworks_base/blob/master/core/java/android/app/SearchDialog.java) as those are the easiest to get. actionModeBackground is always the background - see [search_bar.xml](https://github.com/android/platform_frameworks_base/blob/master/core/res/res/layout/search_bar.xml) which is [used here](https://github.com/android/platform_frameworks_base/blob/master/core/java/android/app/SearchDialog.java#L168).
Since we're using getTheme().obtainStyledAttributes(…) this should also work if actionModeBackground is themed by the app (using styles.xml) if I'm not mistaken.
